### PR TITLE
iPad Bottom Sheet, but at the Bottom ✨

### DIFF
--- a/BottomSheetSwiftUI.podspec
+++ b/BottomSheetSwiftUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                   = 'BottomSheetSwiftUI'
-  spec.version                = '3.0.2'
+  spec.version                = '3.1.0'
   spec.swift_version          = '5.5'
   spec.authors                = { 'Lucas Zischka' => 'lucas_zischka@outlook.com' }
   spec.license                = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 BottomSheet Changelog
 ==================
 
+#### v3.1.0
+- Added the `.iPadFloatingSheet(Bool)` modifier
+- Added the `.sheetWidth(BottomSheetWidth)` modifier
+- Added the `.accountForKeyboardHeight(Bool)` modifier #97
+
 #### v3.0.2
 - Added `.customThreshold(Double)` modifier #8, #88
 

--- a/README.md
+++ b/README.md
@@ -220,14 +220,15 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 `.iPadFloatingSheet(Bool)`: Makes the iPad's bottom sheet be an actual bottom sheet when set to true.
 - The default is `false`.
 
-`.relativeSheetWidth(Double?)`: Sets the relative width of the sheet.
-- Relative to the available width.
-- Max 1, min 0.
-- Set to `nil` to disable, and let the library decide the width.
+`.sheetWidth(BottomSheetWidth)`: Sets the width of the sheet.
+- Can be relative through `BottomSheetWidth.relative(x)`.
+- Can be absolute through `BottomSheetWidth.absolute(x)`.
+- Set to `BottomSheetWidth.platformDefault` to let the library decide the width.
 
 `.accountForKeyboardHeight(Bool)`: Adds bottom padding to the main content equal to the keyboard height when the keyboard appears.
 - The default is `false`.
 - Will not move the sheet further up if the sheet has a smaller height than the keyboard.
+- Not available on Mac.
 
 ## BottomSheetPosition
 

--- a/README.md
+++ b/README.md
@@ -217,18 +217,16 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 - Changing the threshold does not affect whether either option is enabled.
 - The default threshold is 30% (0.3).
 
-`.iPadFloatingSheet(Bool)`: Makes the iPad's bottom sheet be an actual bottom sheet when set to true.
-- The default is `false`.
+`.iPadFloatingSheet(Bool)`: Makes it possible to make the sheet appear like on iPhone.
 
-`.sheetWidth(BottomSheetWidth)`: Sets the width of the sheet.
+`.sheetWidth(BottomSheetWidth)`: Makes it possible to configure a custom sheet width.
 - Can be relative through `BottomSheetWidth.relative(x)`.
 - Can be absolute through `BottomSheetWidth.absolute(x)`.
 - Set to `BottomSheetWidth.platformDefault` to let the library decide the width.
 
-`.accountForKeyboardHeight(Bool)`: Adds bottom padding to the main content equal to the keyboard height when the keyboard appears.
-- The default is `false`.
-- Will not move the sheet further up if the sheet has a smaller height than the keyboard.
-- Not available on Mac.
+`.accountForKeyboardHeight(Bool)`: Adds padding to the bottom of the main content when the keyboard appears so all of the main content is visible.
+- If the height of the sheet is smaller than the height of the keyboard, this modifier will not make the content visible.
+- This behaviour is not active on Mac, because it would not make sense there.
 
 ## BottomSheetPosition
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 - Changing the threshold does not affect whether either option is enabled.
 - The default threshold is 30% (0.3).
 
+`.iPadFloatingSheet(Bool)`: Makes the iPad's bottom sheet be an actual bottom sheet when set to true.
+- The default is `false`.
+
+`.relativeSheetWidth(Double?)`: Sets the relative width of the sheet.
+- Relative to the available width.
+- Max 1, min 0.
+- Set to `nil` to disable, and let the library decide the width.
+
+`.accountForKeyboardHeight(Bool)`: Adds bottom padding to the main content equal to the keyboard height when the keyboard appears.
+- The default is `false`.
+- Will not move the sheet further up if the sheet has a smaller height than the keyboard.
 
 ## BottomSheetPosition
 

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Robin Pel on 06/09/2022.
+//
+
+import Foundation
+
+public extension BottomSheet {
+    
+    /// Adds padding to the bottom of the main content when the keyboard appears so all of the main content is visible.
+    ///
+    /// - Note: If the height of the sheet is smaller than the height of the keyboard, this modifier will not make the content visible.
+    ///
+    /// - Parameters:
+    ///   - bool: A boolean whether the option is enabled.
+    ///
+    /// - Returns: A BottomSheet with its main content shifted up to account for the keyboard when it has appeared.
+    func accountForKeyboardHeight(_ bool: Bool = true) -> BottomSheet {
+        self.configuration.accountForKeyboardHeight = bool
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  BottomSheet+AccountForKeyboardHeight.swift
 //  
 //
 //  Created by Robin Pel on 06/09/2022.

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+AccountForKeyboardHeight.swift
@@ -13,6 +13,8 @@ public extension BottomSheet {
     ///
     /// - Note: If the height of the sheet is smaller than the height of the keyboard, this modifier will not make the content visible.
     ///
+    /// - Note: This behaviour is not active on Mac, because it would not make sense there.
+    ///
     /// - Parameters:
     ///   - bool: A boolean whether the option is enabled.
     ///

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+IPadFloatingSheet.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+IPadFloatingSheet.swift
@@ -1,0 +1,22 @@
+//
+//  BottomSheet+IPadFloatingSheet.swift
+//  
+//
+//  Created by Robin Pel on 05/09/2022.
+//
+
+import Foundation
+
+public extension BottomSheet {
+    
+    /// Makes it possible to make the sheet appear like on iPhone.
+    ///
+    /// - Parameters:
+    ///   - bool: A boolean whether the option is enabled.
+    ///
+    /// - Returns: A BottomSheet that will actually appear at the bottom.
+    func iPadFloatingSheet(_ bool: Bool = true) -> BottomSheet {
+        self.configuration.iPadFloatingSheet = bool
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+RelativeSheetWidth.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+RelativeSheetWidth.swift
@@ -1,0 +1,22 @@
+//
+//  BottomSheet+RelativeSheetWidth.swift
+//  
+//
+//  Created by Robin Pel on 05/09/2022.
+//
+
+import Foundation
+
+public extension BottomSheet {
+    
+    /// Makes it possible to configure a custom sheet width.
+    ///
+    /// - Parameters:
+    ///   - width: The amount of width of the screen the sheet should occupy, 0.5 = 50%, 0.251 = 25.1%, etc.
+    ///
+    /// - Returns: A BottomSheet with the configured width.
+    func relativeSheetWidth(_ width: Double? = nil) -> BottomSheet {
+        self.configuration.relativeSheetWidth = width
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetWidth.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetWidth.swift
@@ -1,5 +1,5 @@
 //
-//  BottomSheet+RelativeSheetWidth.swift
+//  BottomSheet+SheetWidth.swift
 //  
 //
 //  Created by Robin Pel on 05/09/2022.
@@ -12,11 +12,11 @@ public extension BottomSheet {
     /// Makes it possible to configure a custom sheet width.
     ///
     /// - Parameters:
-    ///   - width: The amount of width of the screen the sheet should occupy, 0.5 = 50%, 0.251 = 25.1%, etc.
+    ///   - width: The width to use for the bottom sheet.
     ///
     /// - Returns: A BottomSheet with the configured width.
-    func relativeSheetWidth(_ width: Double? = nil) -> BottomSheet {
-        self.configuration.relativeSheetWidth = width
+    func sheetWidth(_ width: BottomSheetWidth = .platformDefault) -> BottomSheet {
+        self.configuration.sheetWidth = width
         return self
     }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -171,7 +171,10 @@ internal extension BottomSheetView {
             )
             
         case .absolute(let width):
-            return width
+            return max(
+                0,
+                width
+            )
         }
     }
     

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -155,13 +155,27 @@ internal extension BottomSheetView {
     
     // For iPhone landscape, iPad and Mac support
     func width(with geometry: GeometryProxy) -> CGFloat {
-        
-        if let widthOverride = self.configuration.relativeSheetWidth {
-            // When the width is overriden, use it
-            // But don't allow it to be smaller than zero, or larger than one
-            return geometry.size.width * max(0, min(1, widthOverride))
+        switch self.configuration.sheetWidth {
+            
+        case .platformDefault:
+            return self.platformDefaultWidth(with: geometry)
+            
+        case .relative(let width):
+            // Don't allow the width to be smaller than zero, or larger than one
+            return geometry.size.width * max(
+                0,
+                min(
+                    1,
+                    width
+                )
+            )
+            
+        case .absolute(let width):
+            return width
         }
-        
+    }
+    
+    func platformDefaultWidth(with geometry: GeometryProxy) -> CGFloat {
 #if os(macOS)
         // On Mac use 30% of the width
         return geometry.size.width * 0.3

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -160,10 +160,13 @@ internal extension BottomSheetView {
             // When the width is overriden, use it
             // But don't allow it to be smaller than zero, or larger than one
             return geometry.size.width * max(0, min(1, widthOverride))
-        } else if self.isMac {
-            // On Mac use 30% of the width
-            return geometry.size.width * 0.3
-        } else if self.isIPad {
+        }
+        
+#if os(macOS)
+        // On Mac use 30% of the width
+        return geometry.size.width * 0.3
+#else
+        if self.isIPad {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
         } else if UIDevice.current.orientation.isLandscape {
@@ -173,6 +176,7 @@ internal extension BottomSheetView {
             // On iPhone portrait use 100% of the width
             return geometry.size.width
         }
+#endif
     }
     
     // For `backgroundBlur`

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Gestures.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Gestures.swift
@@ -14,7 +14,7 @@ internal extension BottomSheetView {
                 // Perform custom onChanged action
                 self.configuration.onDragChanged(value)
                 
-                // Update translation; on iPad and Mac the drag direction is reversed
+                // Update translation; on iPad floating and Mac the drag direction is reversed
                 self.translation = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
                 // Dismiss the keyboard on drag
                 self.endEditing()
@@ -51,7 +51,7 @@ internal extension BottomSheetView {
                     
                     // Notify the ScrollView that the user is dragging
                     self.dragState = .none
-                    // Update translation; on iPad and Mac the drag direction is reversed
+                    // Update translation; on iPad floating and Mac the drag direction is reversed
                     self.translation = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
                 }
                 

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Gestures.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Gestures.swift
@@ -15,7 +15,7 @@ internal extension BottomSheetView {
                 self.configuration.onDragChanged(value)
                 
                 // Update translation; on iPad and Mac the drag direction is reversed
-                self.translation = self.isIPadOrMac ? -value.translation.height : value.translation.height
+                self.translation = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
                 // Dismiss the keyboard on drag
                 self.endEditing()
             }
@@ -52,7 +52,7 @@ internal extension BottomSheetView {
                     // Notify the ScrollView that the user is dragging
                     self.dragState = .none
                     // Update translation; on iPad and Mac the drag direction is reversed
-                    self.translation = self.isIPadOrMac ? -value.translation.height : value.translation.height
+                    self.translation = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
                 }
                 
                 // Dismiss the keyboard on dragging/scrolling

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -197,6 +197,11 @@ internal extension BottomSheetView {
             .top,
             self.headerContentHeight
         )
+        // Add padding to the bottom to compensate for the keyboard (if desired)
+        .padding(
+            .bottom,
+            !self.isIPadFloatingOrMac && self.configuration.accountForKeyboardHeight ? keyboardHeight.value : 0
+        )
         // Make the main content transition via move
         .transition(.move(
             edge: self.isIPadFloatingOrMac ? .top : .bottom

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -36,27 +36,28 @@ internal extension BottomSheetView {
             alignment: .center,
             spacing: 0
         ) {
-            // Drag indicator on the top (iPhone)
-            if self.configuration.isResizable && self.configuration.isDragIndicatorShown && !self.isIPadOrMac {
+            // Drag indicator on the top (iPhone and iPad not floating)
+            if self.configuration.isResizable && self.configuration.isDragIndicatorShown && !self.isIPadFloatingOrMac {
                 self.dragIndicator( with: geometry)
             }
             
             // The header an main content
             self.bottomSheetContent(with: geometry)
             
-            // Drag indicator on the bottom (iPad and Mac)
-            if self.configuration.isResizable && self.configuration.isDragIndicatorShown && self.isIPadOrMac {
+            // Drag indicator on the bottom (iPad floating and Mac)
+            if self.configuration.isResizable && self.configuration.isDragIndicatorShown && self.isIPadFloatingOrMac {
                 self.dragIndicator(with: geometry)
             }
         }
         // Set the height and width to its calculated values
         // The content should be aligned to the top on iPhone,
-        // on iPad and Mac to the bottom for transition to work correctly
-        // Don't set height if `.dynamic...` and currently not dragging
+        // on iPad floating and Mac to the bottom for transition
+        // to work correctly. Don't set height if `.dynamic...`
+        // and currently not dragging
         .frame(
             width: self.width(with: geometry),
             height: self.bottomSheetPosition.isDynamic && self.translation == 0 ? nil : self.height(with: geometry),
-            alignment: self.isIPadOrMac ? .bottom : .top
+            alignment: self.isIPadFloatingOrMac ? .bottom : .top
         )
         // Clip BottomSheet for transition to work correctly for iPad and Mac
         .clipped()
@@ -64,18 +65,18 @@ internal extension BottomSheetView {
         .background(
             self.bottomSheetBackground(with: geometry)
         )
-        // On iPad and Mac the BottomSheet has a padding
+        // On iPad floating and Mac the BottomSheet has a padding
         .padding(
-            self.isIPadOrMac ? 10 : 0
+            self.isIPadFloatingOrMac ? 10 : 0
         )
         // Add safe area top padding on iPad and Mac
         .padding(
             .top,
-            self.iPadAndMacTopPadding
+            self.topPadding
         )
         // Make the BottomSheet transition via move
         .transition(.move(
-            edge: self.isIPadOrMac ? .top : .bottom
+            edge: self.isIPadFloatingOrMac ? .top : .bottom
         ))
     }
     
@@ -162,8 +163,8 @@ internal extension BottomSheetView {
         VStack(alignment: .center, spacing: 0) {
             if self.configuration.isAppleScrollBehaviorEnabled && self.configuration.isResizable {
                 // Content for `appleScrollBehaviour`
-                if self.isIPadOrMac {
-                    // On iPad an Mac use a normal ScrollView
+                if self.isIPadFloatingOrMac {
+                    // On iPad floating an Mac use a normal ScrollView
                     ScrollView {
                         self.mainContent
                     }
@@ -187,7 +188,7 @@ internal extension BottomSheetView {
         // Align content correctly and make it use all available space to fix transition
         .frame(
             maxHeight: self.maxMainContentHeight(with: geometry),
-            alignment: self.isIPadOrMac ? .bottom : .top
+            alignment: self.isIPadFloatingOrMac ? .bottom : .top
         )
         // Clip main content so that it doesn't go beneath the header content
         .clipped()
@@ -198,7 +199,7 @@ internal extension BottomSheetView {
         )
         // Make the main content transition via move
         .transition(.move(
-            edge: self.isIPadOrMac ? .top : .bottom
+            edge: self.isIPadFloatingOrMac ? .top : .bottom
         ))
     }
     
@@ -303,7 +304,7 @@ internal extension BottomSheetView {
                 // Only add top padding if no drag indicator
                     .padding(
                         (!self.configuration.isDragIndicatorShown || !self.configuration.isResizable) ||
-                        self.isIPadOrMac ? .top : []
+                        self.isIPadFloatingOrMac ? .top : []
                     )
             }
         }
@@ -362,11 +363,11 @@ internal extension BottomSheetView {
                 // Default BottomSheet background
                 VisualEffectView(visualEffect: .system)
                 // Add corner radius to BottomSheet background
-                // On iPhone only to the top corners,
-                // on iPad and Mac to all corners
+                // On iPhone and iPad not floating only to the top corners,
+                // on iPad floating and Mac to all corners
                     .cornerRadius(
                         10,
-                        corners: self.isIPadOrMac ? .allCorners : [
+                        corners: self.isIPadFloatingOrMac ? .allCorners : [
                             .topRight,
                             .topLeft
                         ]

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -200,7 +200,7 @@ internal extension BottomSheetView {
         // Add padding to the bottom to compensate for the keyboard (if desired)
         .padding(
             .bottom,
-            !self.isIPadFloatingOrMac && self.configuration.accountForKeyboardHeight ? keyboardHeight.value : 0
+            self.mainContentBottomPadding
         )
         // Make the main content transition via move
         .transition(.move(
@@ -383,5 +383,19 @@ internal extension BottomSheetView {
         .gesture(
             self.configuration.isResizable ? self.dragGesture(with: geometry) : nil
         )
+    }
+    
+    var mainContentBottomPadding: CGFloat {
+        
+        if !self.isIPadFloatingOrMac && self.configuration.accountForKeyboardHeight {
+#if !os(macOS)
+            return keyboardHeight.value
+#else
+            // Should not be reached
+            return 0
+#endif
+        } else {
+            return 0
+        }
     }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -386,7 +386,6 @@ internal extension BottomSheetView {
     }
     
     var mainContentBottomPadding: CGFloat {
-        
         if !self.isIPadFloatingOrMac && self.configuration.accountForKeyboardHeight {
 #if !os(macOS)
             return keyboardHeight.value

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+KeyboardHeight.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+KeyboardHeight.swift
@@ -5,6 +5,7 @@
 //  Created by Robin Pel on 06/09/2022.
 //
 
+#if !os(macOS)
 import UIKit
 import SwiftUI
 
@@ -39,3 +40,4 @@ internal class KeyboardHeight: ObservableObject {
         value = 0
     }
 }
+#endif

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+KeyboardHeight.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+KeyboardHeight.swift
@@ -1,0 +1,41 @@
+//
+//  BottomSheetView+KeyboardHeight.swift
+//  
+//
+//  Created by Robin Pel on 06/09/2022.
+//
+
+import UIKit
+import SwiftUI
+
+internal class KeyboardHeight: ObservableObject {
+    
+    @Published private(set) internal var value: CGFloat = 0
+    
+    internal init() {
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            value = keyboardFrame.cgRectValue.height
+        }
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        value = 0
+    }
+}

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+SwitchPosition.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+SwitchPosition.swift
@@ -18,7 +18,7 @@ internal extension BottomSheetView {
         if let dragPositionSwitchAction = self.configuration.dragPositionSwitchAction {
             dragPositionSwitchAction(geometry, value)
         } else {
-            // On iPad and Mac the drag direction is reversed
+            // On iPad floating and Mac the drag direction is reversed
             let translationHeight: CGFloat = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
             // The height in percent relative to the screen height the user has dragged
             let height: CGFloat = translationHeight / geometry.size.height

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+SwitchPosition.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+SwitchPosition.swift
@@ -19,7 +19,7 @@ internal extension BottomSheetView {
             dragPositionSwitchAction(geometry, value)
         } else {
             // On iPad and Mac the drag direction is reversed
-            let translationHeight: CGFloat = self.isIPadOrMac ? -value.translation.height : value.translation.height
+            let translationHeight: CGFloat = self.isIPadFloatingOrMac ? -value.translation.height : value.translation.height
             // The height in percent relative to the screen height the user has dragged
             let height: CGFloat = translationHeight / geometry.size.height
             

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -28,6 +28,8 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
     @State var headerContentHeight: CGFloat = 0
     @State var dynamicMainContentHeight: CGFloat = 0
     
+    @ObservedObject var keyboardHeight: KeyboardHeight = .init()
+    
     // Views
     let headerContent: HContent?
     let mainContent: MContent

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -44,7 +44,7 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
             ZStack(
                 // On iPad and Mac the BottomSheet is aligned to the top left
                 // On iPhone it is aligned to the bottom center, in horizontal mode to the bottom left
-                alignment: self.isIPadOrMac ? .topLeading : .bottomLeading
+                alignment: self.isIPadFloatingOrMac ? .topLeading : .bottomLeading
             ) {
                 // Hide everything when the BottomSheet is hidden
                 if !self.bottomSheetPosition.isHidden {
@@ -101,7 +101,7 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
         // On iPhone ignore bottom safe area, because the BottomSheet moves to the bottom edge
         // On iPad and Mac ignore top safe area, because the BottomSheet moves to the top edge
         .edgesIgnoringSafeArea(
-            self.isIPadOrMac ? .top : .bottom
+            self.isIPadFloatingOrMac ? .top : .bottom
         )
     }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -28,7 +28,9 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
     @State var headerContentHeight: CGFloat = 0
     @State var dynamicMainContentHeight: CGFloat = 0
     
+#if !os(macOS)
     @ObservedObject var keyboardHeight: KeyboardHeight = .init()
+#endif
     
     // Views
     let headerContent: HContent?

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -42,8 +42,9 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
         GeometryReader { geometry in
             // ZStack for aligning content
             ZStack(
-                // On iPad and Mac the BottomSheet is aligned to the top left
-                // On iPhone it is aligned to the bottom center, in horizontal mode to the bottom left
+                // On iPad floating and Mac the BottomSheet is aligned to the top left
+                // On iPhone and iPad not floating it is aligned to the bottom center,
+                // in horizontal mode to the bottom left
                 alignment: self.isIPadFloatingOrMac ? .topLeading : .bottomLeading
             ) {
                 // Hide everything when the BottomSheet is hidden
@@ -98,8 +99,8 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
             )
         }
         // Make the GeometryReader ignore specific safe area (for transition to work)
-        // On iPhone ignore bottom safe area, because the BottomSheet moves to the bottom edge
-        // On iPad and Mac ignore top safe area, because the BottomSheet moves to the top edge
+        // On iPhone and iPad not floating ignore bottom safe area, because the BottomSheet moves to the bottom edge
+        // On iPad floating and Mac ignore top safe area, because the BottomSheet moves to the top edge
         .edgesIgnoringSafeArea(
             self.isIPadFloatingOrMac ? .top : .bottom
         )

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -25,7 +25,9 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isFlickThroughEnabled == rhs.isFlickThroughEnabled &&
         lhs.isResizable == rhs.isResizable &&
         lhs.isSwipeToDismissEnabled && rhs.isSwipeToDismissEnabled &&
-        lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled
+        lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
+        lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
+        lhs.relativeSheetWidth == rhs.relativeSheetWidth
     }
     
     var animation: Animation? = .spring(
@@ -55,4 +57,6 @@ internal class BottomSheetConfiguration: Equatable {
     var onDragEnded: (DragGesture.Value) -> Void = { _ in }
     var onDragChanged: (DragGesture.Value) -> Void = { _ in }
     var threshold: Double = 0.3
+    var iPadFloatingSheet: Bool = true
+    var relativeSheetWidth: Double? = nil
 }

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -27,7 +27,7 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isSwipeToDismissEnabled && rhs.isSwipeToDismissEnabled &&
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
-        lhs.relativeSheetWidth == rhs.relativeSheetWidth &&
+        lhs.sheetWidth == rhs.sheetWidth &&
         lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight
     }
     
@@ -59,6 +59,6 @@ internal class BottomSheetConfiguration: Equatable {
     var onDragChanged: (DragGesture.Value) -> Void = { _ in }
     var threshold: Double = 0.3
     var iPadFloatingSheet: Bool = true
-    var relativeSheetWidth: Double? = nil
+    var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
 }

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -27,7 +27,8 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isSwipeToDismissEnabled && rhs.isSwipeToDismissEnabled &&
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
-        lhs.relativeSheetWidth == rhs.relativeSheetWidth
+        lhs.relativeSheetWidth == rhs.relativeSheetWidth &&
+        lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight
     }
     
     var animation: Animation? = .spring(
@@ -59,4 +60,5 @@ internal class BottomSheetConfiguration: Equatable {
     var threshold: Double = 0.3
     var iPadFloatingSheet: Bool = true
     var relativeSheetWidth: Double? = nil
+    var accountForKeyboardHeight: Bool = false
 }

--- a/Sources/BottomSheet/Models/BottomSheetWidth.swift
+++ b/Sources/BottomSheet/Models/BottomSheetWidth.swift
@@ -1,0 +1,21 @@
+//
+//  BottomSheetWidth.swift
+//  
+//
+//  Created by Robin Pel on 07/09/2022.
+//
+
+import SwiftUI
+
+/// `BottomSheetWidth` defines the possible bottom sheet widths that can be configured.
+public enum BottomSheetWidth: Equatable {
+    
+    /// Apply the platform default width to the sheet.
+    case platformDefault
+    
+    /// The width of the sheet has to be x% of the available width.
+    case relative(CGFloat)
+    
+    /// The width of the sheet has to be x.
+    case absolute(CGFloat)
+}

--- a/Sources/BottomSheet/Models/BottomSheetWidth.swift
+++ b/Sources/BottomSheet/Models/BottomSheetWidth.swift
@@ -8,14 +8,31 @@
 import SwiftUI
 
 /// `BottomSheetWidth` defines the possible bottom sheet widths that can be configured.
+///
+/// Currently there are three options:
+/// - `.platformDefault`, which let's the library decide the width while taking the platform into account.
+/// - `.relative(CGFloat)`, which sets the width to a certain percentage of the available width.
+/// - `.absolute(CGFloat)`, which sets the width to the given amount.
 public enum BottomSheetWidth: Equatable {
     
     /// Apply the platform default width to the sheet.
+    ///
+    /// As from `BottomSheetView.platformDefaultWidth`:
+    /// - Mac: 30% of the available width.
+    /// - iPad: 30% of the available width.
+    /// - iPhone landscape: 40% of the available width.
+    /// - iPhone portrait: 100% of the available width.
     case platformDefault
     
     /// The width of the sheet has to be x% of the available width.
+    ///
+    /// Only values between 0 and 1 make sense.
+    /// If you want to hide the sheet, please use `BottomSheetPosition.hidden`.
     case relative(CGFloat)
     
     /// The width of the sheet has to be x.
+    ///
+    /// Only values above 0 make sense.
+    /// If you want to hide the sheet, please use `BottomSheetPosition.hidden`.
     case absolute(CGFloat)
 }


### PR DESCRIPTION
Hi! 

I like this library, but it would be awesome if the bottom sheet could actually be at the bottom on an iPad. 😁

So... that's where this PR is for! I've also added a modifier that enables you to override the sheet width, and a modifier that adds bottom padding to the main content if the keyboard is opened (which should fix this issue I believe: #97 ).

---

### iPad Demo

#### View's Code

```swift
VStack {
    Button("TESTING APP 🦆") {}
}
.bottomSheet(
    bottomSheetPosition: $position,
    switchablePositions: [.dynamicBottom, .absolute(400), .absolute(600), .relativeTop(1)],
    headerContent: { Text("Bottom Sheet Title").font(.title.bold()) },
    mainContent: {
        VStack {
            Divider().padding()
            TextEditor(text: $loremIpsum)
        }
    }
)
.iPadFloatingSheet(false)
.relativeSheetWidth(1.0)
.accountForKeyboardHeight()
```

#### Without the keyboard auto adjust

https://user-images.githubusercontent.com/103025931/188599117-40a26131-a6cd-4855-9239-16ec7067b475.mp4

#### With the keyboard auto adjust

https://user-images.githubusercontent.com/103025931/188599133-7fcad1ac-8700-44e0-a646-267ebd207f51.mp4

---

I'm looking forward to your feedback! 😊


