### PR TITLE
fix(animations): make inner views animated only when necessary

### DIFF
--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -24,7 +24,7 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isDragIndicatorShown == rhs.isDragIndicatorShown &&
         lhs.isFlickThroughEnabled == rhs.isFlickThroughEnabled &&
         lhs.isResizable == rhs.isResizable &&
-        lhs.isSwipeToDismissEnabled && rhs.isSwipeToDismissEnabled &&
+        lhs.isSwipeToDismissEnabled == rhs.isSwipeToDismissEnabled &&
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
         lhs.sheetWidth == rhs.sheetWidth &&


### PR DESCRIPTION
If we turn off the `swipeToDismiss` functionality, the inner views (and the whole bottom sheet) is always animated, no matter what values changes.
This is because of `self.configuration` property (which is configured to trigger an animation) always returning `false` for the equality function `==`. 
It seems like a mistake in the equality function, where it accidentally checks for both `lhs.isSwipeToDismissEnabled` and `rhs.isSwipeToDismissEnabled` instead of just comparing them to each other (and they return `false` because we turned off the `swipeToDismiss` functionality).