### PR TITLE
Fix issue #101

### DIFF
--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+DragIndicator.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+DragIndicator.swift
@@ -53,4 +53,15 @@ public extension BottomSheet {
         self.configuration.dragIndicatorAction = action
         return self
     }
+    
+    /// Enables the animations on drag indicator
+    ///
+    /// - Parameters:
+    ///   - bool: A boolean to decide whether or not animations should be discarded.
+    ///
+    /// - Returns: A BottomSheet with animations on drag indicator enabled
+    func enableAnimationsOnDragIndicator(_ bool: Bool = true) -> BottomSheet {
+        self.configuration.enableAnimationsOnDragIndicator = bool
+        return self
+    }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -89,7 +89,7 @@ internal extension BottomSheetView {
                 Capsule()
                 // Design of the drag indicator
                     .fill(self.configuration.dragIndicatorColor)
-                    .frame(
+                                        .frame(
                         width: 36,
                         height: 5
                     )
@@ -105,9 +105,19 @@ internal extension BottomSheetView {
                     .gesture(
                         self.dragGesture(with: geometry)
                     )
+                    
             })
-        // Make it borderless for Mac
+            // Make it borderless for Mac
             .buttonStyle(.borderless)
+        
+            // Disable animations
+            .if(!configuration.enableAnimationsOnDragIndicator) { view in
+                view
+                    .transaction { t in
+                        t.disablesAnimations = true
+
+                    }
+            }
     }
     
     func bottomSheetContent(with geometry: GeometryProxy) -> some View {

--- a/Sources/BottomSheet/Helper/Extensions/ConditionalViewExtension.swift
+++ b/Sources/BottomSheet/Helper/Extensions/ConditionalViewExtension.swift
@@ -1,0 +1,22 @@
+//
+//  ConditionalViewModifier.swift
+//  
+//  Created by GrandSir on 10.03.2023.
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies the given transform if the given condition evaluates to `true`.
+    /// - Parameters:
+    ///   - condition: The condition to evaluate.
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -61,4 +61,5 @@ internal class BottomSheetConfiguration: Equatable {
     var iPadFloatingSheet: Bool = true
     var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
+    var enableAnimationsOnDragIndicator = false
 }


### PR DESCRIPTION
this commit adds a modifier called `enableAnimationsOnDragIndicator`, which enables the animations on drag indicator, it is false by default, so that issue on 101 is fixed by default as well, only will occur if you add `enableAnimationsOnDragIndicator` to the view, I added that because maybe someone will want to add some animations, more customization is better.


the left phone is with enableAnimationsOnDragIndicator , and the right is without it.

https://user-images.githubusercontent.com/69051988/224480371-6378d5c3-976d-407d-a5fa-94c4dabc4228.mp4

