### PR TITLE
Fix dragging of sheet when dragging is started on top of button or other pressable item

### DIFF
--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -181,7 +181,8 @@ internal extension BottomSheetView {
                 // Main content
                 self.mainContent
                 // Make the main content drag-able if content drag is enabled
-                    .gesture(
+                // highPriorityGesture is required to make dragging the bottom sheet work even when user starts dragging on buttons or other pressable items
+                    .highPriorityGesture(
                         self.configuration.isContentDragEnabled && self.configuration.isResizable ?
                         self.dragGesture(with: geometry) : nil
                     )


### PR DESCRIPTION
.highPriorityGesture is required to make dragging the bottom sheet work even when user starts dragging on buttons or other pressable items