### PR TITLE
iPad sheet alignment and side padding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 
 `.enableFloatingIPadSheet(Bool)`: Makes it possible to make the sheet appear like on iPhone.
 
-`.iPadSheetAlignment(Alignment)`: Allows for different alignments of the sheet when enableFloatingIPadSheet is disabled.
+`.iPadSheetAlignment(Alignment)`: Allows for different alignments of the sheet on iPad when enableFloatingIPadSheet is disabled.
+
+`.sheetPadding(CGFloat)`: Gives the bottom sheet padding on iPad when enableFloatingIPadSheet is disabled.
 
 `.onDismiss(() -> Void)`: A action that will be performed when the BottomSheet is dismissed.
 -  Please note that when you dismiss the BottomSheet yourself, by setting the bottomSheetPosition to .hidden, the action will not be called.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 
 `.iPadSheetAlignment(Alignment)`: Allows for different alignments of the sheet on iPad when enableFloatingIPadSheet is disabled.
 
-`.sheetPadding(CGFloat)`: Gives the bottom sheet padding on iPad when enableFloatingIPadSheet is disabled.
+`.sheetSidePadding(CGFloat)`: Gives the bottom sheet horizontal padding on iPad when enableFloatingIPadSheet is disabled.
 
 `.onDismiss(() -> Void)`: A action that will be performed when the BottomSheet is dismissed.
 -  Please note that when you dismiss the BottomSheet yourself, by setting the bottomSheetPosition to .hidden, the action will not be called.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The ViewModifiers are used to customise the look and feel of the BottomSheet.
 
 `.enableFloatingIPadSheet(Bool)`: Makes it possible to make the sheet appear like on iPhone.
 
+`.iPadSheetAlignment(Alignment)`: Allows for different alignments of the sheet when enableFloatingIPadSheet is disabled.
+
 `.onDismiss(() -> Void)`: A action that will be performed when the BottomSheet is dismissed.
 -  Please note that when you dismiss the BottomSheet yourself, by setting the bottomSheetPosition to .hidden, the action will not be called.
 

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetPadding.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetPadding.swift
@@ -1,0 +1,22 @@
+//
+//  BottomSheet+SheetPadding.swift
+//  
+//  Created by Lucas Zischka.
+//  Copyright © 2022 Lucas Zischka. All rights reserved.
+//
+
+import Foundation
+
+public extension BottomSheet {
+    
+    /// Gives padding to the sheet
+    ///
+    /// - Parameters:
+    ///   - padding: The padding to use for the bottom sheet.
+    ///
+    /// - Returns: A BottomSheet with the configured padding.
+    func sheetPadding(_ padding: CGFloat = 0.0) -> BottomSheet {
+        self.configuration.sheetPadding = padding
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetSidePadding.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+SheetSidePadding.swift
@@ -1,6 +1,6 @@
 //
-//  BottomSheet+SheetPadding.swift
-//  
+//  BottomSheet+SheetSidePadding.swift
+//
 //  Created by Lucas Zischka.
 //  Copyright © 2022 Lucas Zischka. All rights reserved.
 //
@@ -9,14 +9,14 @@ import Foundation
 
 public extension BottomSheet {
     
-    /// Gives padding to the sheet
+    /// Gives horizontal padding to the sheet
     ///
     /// - Parameters:
     ///   - padding: The padding to use for the bottom sheet.
     ///
     /// - Returns: A BottomSheet with the configured padding.
-    func sheetPadding(_ padding: CGFloat = 0.0) -> BottomSheet {
-        self.configuration.sheetPadding = padding
+    func sheetSidePadding(_ padding: CGFloat = 0.0) -> BottomSheet {
+        self.configuration.sheetSidePadding = padding
         return self
     }
 }

--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+iPadSheetAlignment.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+iPadSheetAlignment.swift
@@ -1,0 +1,23 @@
+//
+//  BottomSheet+iPadSheetAlignment.swift
+//
+//  Created by Lucas Zischka.
+//  Copyright © 2022 Lucas Zischka. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+public extension BottomSheet {
+    
+    /// Makes it possible to align the sheet at different places on iPad if floating sheet is disabled
+    ///
+    /// - Parameters:
+    ///   - alignment: An alignment for the bottom sheet
+    ///
+    /// - Returns: A BottomSheet that will align to what's specified
+    func iPadSheetAlignment(_ alignment: Alignment = .bottomLeading) -> BottomSheet {
+        self.configuration.iPadSheetAlignment = alignment
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -74,7 +74,7 @@ internal extension BottomSheetView {
             .top,
             self.topPadding
         )
-        // Add safe area top padding on iPad and Mac
+        // Add side padding
         .padding(
             .horizontal,
             self.configuration.sheetSidePadding

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -67,7 +67,7 @@ internal extension BottomSheetView {
         )
         // On iPad floating and Mac the BottomSheet has a padding
         .padding(
-            self.isIPadFloatingOrMac ? 10 : 0
+            self.isIPadFloatingOrMac ? 10 : self.configuration.sheetPadding
         )
         // Add safe area top padding on iPad and Mac
         .padding(

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -67,12 +67,17 @@ internal extension BottomSheetView {
         )
         // On iPad floating and Mac the BottomSheet has a padding
         .padding(
-            self.isIPadFloatingOrMac ? 10 : self.configuration.sheetPadding
+            self.isIPadFloatingOrMac ? 10 : 0
         )
         // Add safe area top padding on iPad and Mac
         .padding(
             .top,
             self.topPadding
+        )
+        // Add safe area top padding on iPad and Mac
+        .padding(
+            .horizontal,
+            self.configuration.sheetSidePadding
         )
         // Make the BottomSheet transition via move
         .transition(.move(

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -51,7 +51,7 @@ internal struct BottomSheetView<HContent: View, MContent: View>: View {
                 // On iPad floating and Mac the BottomSheet is aligned to the top left
                 // On iPhone and iPad not floating it is aligned to the bottom center,
                 // in horizontal mode to the bottom left
-                alignment: self.isIPadFloatingOrMac ? .topLeading : .bottomLeading
+                alignment: self.isIPadFloatingOrMac ? .topLeading : self.configuration.iPadSheetAlignment
             ) {
                 // Hide everything when the BottomSheet is hidden
                 if !self.bottomSheetPosition.isHidden {

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -29,7 +29,8 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
         lhs.sheetWidth == rhs.sheetWidth &&
         lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight &&
-        lhs.iPadSheetAlignment == rhs.iPadSheetAlignment
+        lhs.iPadSheetAlignment == rhs.iPadSheetAlignment &&
+        lhs.sheetPadding == rhs.sheetPadding
     }
     
     var animation: Animation? = .spring(
@@ -63,4 +64,5 @@ internal class BottomSheetConfiguration: Equatable {
     var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
     var iPadSheetAlignment: Alignment = .bottomLeading
+    var sheetPadding: CGFloat = 0.0
 }

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -30,7 +30,7 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.sheetWidth == rhs.sheetWidth &&
         lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight &&
         lhs.iPadSheetAlignment == rhs.iPadSheetAlignment &&
-        lhs.sheetPadding == rhs.sheetPadding
+        lhs.sheetSidePadding == rhs.sheetSidePadding
     }
     
     var animation: Animation? = .spring(
@@ -64,5 +64,5 @@ internal class BottomSheetConfiguration: Equatable {
     var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
     var iPadSheetAlignment: Alignment = .bottomLeading
-    var sheetPadding: CGFloat = 0.0
+    var sheetSidePadding: CGFloat = 0.0
 }

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -28,7 +28,8 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
         lhs.sheetWidth == rhs.sheetWidth &&
-        lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight
+        lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight &&
+        lhs.iPadSheetAlignment == rhs.iPadSheetAlignment
     }
     
     var animation: Animation? = .spring(
@@ -61,4 +62,5 @@ internal class BottomSheetConfiguration: Equatable {
     var iPadFloatingSheet: Bool = true
     var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
+    var iPadSheetAlignment: Alignment = .bottomLeading
 }


### PR DESCRIPTION
By default the BottomSheet on iPads will appear over the top left corner of the screen.
The top placement can be changed to the bottom by setting `enableFloatingIPadSheet ` to false, but the sheet stays align to the .bottomLeading alignment.

In order for the sheet to be placed on the right side of the screen a new modifier called `iPadSheetAlignment` has been added. 

Also another modifier called `sheetSidePadding` was added to allow for side padding of the sheet to prevent the sheet from hugging the side. 


Default iPad Sheet:
![Simulator Screenshot - iPad mini (6th generation) - 2024-04-06 at 11 00 22](https://github.com/lucaszischka/BottomSheet/assets/30836017/30247c5b-034e-47a8-aa95-8ca90de24f15)


iPad Sheet with  enableFloatingIPadSheet set to false:
![Simulator Screenshot - iPad mini (6th generation) - 2024-04-06 at 10 47 25](https://github.com/lucaszischka/BottomSheet/assets/30836017/59605d84-60da-4d7b-94dd-ace1e18557e0)



iPad Sheet with enableFloatingIPadSheet set to false, iPadSheetAlignment set to .bottomTrailing, and sheetSidePadding set to 20:

![Simulator Screenshot - iPad mini (6th generation) - 2024-04-06 at 10 47 06](https://github.com/lucaszischka/BottomSheet/assets/30836017/e36494e0-3bd4-4011-8e66-5bec5a6bd819)


