### PR TITLE
Custom bottom content offset for BottomSheet

### DIFF
--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -55,7 +55,6 @@ public struct BottomSheet<HContent: View, MContent: View, V: View>: View {
         self.view = view
         self.configuration = BottomSheetConfiguration()
         if bottomOffset > 0 {
-            print("set custom bottom offset as \(bottomOffset)")
             self.configuration.customBottomOffset = bottomOffset
         }
     }

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -17,9 +17,10 @@ public struct BottomSheet<HContent: View, MContent: View, V: View>: View {
     private let mainContent: MContent
     
     private let switchablePositions: [BottomSheetPosition]
+    private let bottomOffset: CGFloat
     
     // Configuration
-    internal let configuration: BottomSheetConfiguration = BottomSheetConfiguration()
+    internal let configuration: BottomSheetConfiguration
     
     public var body: some View {
         // ZStack for creating the overlay on the original view
@@ -41,20 +42,28 @@ public struct BottomSheet<HContent: View, MContent: View, V: View>: View {
     internal init(
         bottomSheetPosition: Binding<BottomSheetPosition>,
         switchablePositions: [BottomSheetPosition],
+        bottomOffset: CGFloat = 0,
         headerContent: HContent?,
         mainContent: MContent,
         view: V
     ) {
         self._bottomSheetPosition = bottomSheetPosition
         self.switchablePositions = switchablePositions
+        self.bottomOffset = bottomOffset
         self.headerContent = headerContent
         self.mainContent = mainContent
         self.view = view
+        self.configuration = BottomSheetConfiguration()
+        if bottomOffset > 0 {
+            print("set custom bottom offset as \(bottomOffset)")
+            self.configuration.customBottomOffset = bottomOffset
+        }
     }
     
     internal init(
         bottomSheetPosition: Binding<BottomSheetPosition>,
         switchablePositions: [BottomSheetPosition],
+        bottomOffset: CGFloat = 0,
         title: String?,
         content: MContent,
         view: V
@@ -62,6 +71,7 @@ public struct BottomSheet<HContent: View, MContent: View, V: View>: View {
         self.init(
             bottomSheetPosition: bottomSheetPosition,
             switchablePositions: switchablePositions,
+            bottomOffset: bottomOffset,
             headerContent: {
                 if let title = title {
                     return Text(title)
@@ -94,6 +104,7 @@ public extension View {
     func bottomSheet<HContent: View, MContent: View>(
         bottomSheetPosition: Binding<BottomSheetPosition>,
         switchablePositions: [BottomSheetPosition],
+        bottomOffset: CGFloat = 0,
         @ViewBuilder headerContent: () -> HContent? = {
             return nil
         },
@@ -102,6 +113,7 @@ public extension View {
         BottomSheet(
             bottomSheetPosition: bottomSheetPosition,
             switchablePositions: switchablePositions,
+            bottomOffset: bottomOffset,
             headerContent: headerContent(),
             mainContent: mainContent(),
             view: self
@@ -123,12 +135,14 @@ public extension View {
     func bottomSheet<MContent: View>(
         bottomSheetPosition: Binding<BottomSheetPosition>,
         switchablePositions: [BottomSheetPosition],
+        bottomOffset: CGFloat = 0,
         title: String? = nil,
         @ViewBuilder content: () -> MContent
     ) -> BottomSheet<TitleContent, MContent, Self> {
         BottomSheet(
             bottomSheetPosition: bottomSheetPosition,
             switchablePositions: switchablePositions,
+            bottomOffset: bottomOffset,
             title: title,
             content: content(),
             view: self

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -61,10 +61,14 @@ internal extension BottomSheetView {
     // The height of the spacer when position is bottom
     var bottomPositionSpacerHeight: CGFloat? {
         // Only limit height when dynamic
-        if self.bottomSheetPosition.isDynamic {
+        if self.bottomSheetPosition.isDynamic && self.bottomSheetPosition == .dynamicBottom {
             // When dynamic return safe area and header height
             return self.bottomPositionSafeAreaHeight + self.headerContentHeight
-        } else {
+        } else if self.bottomSheetPosition.isDynamic && self.bottomSheetPosition == .dynamic {
+            print("headerContentHeight: \(headerContentHeight), dynamicMainContentHeight: \(dynamicMainContentHeight)")
+            return self.bottomPositionSafeAreaHeight + self.headerContentHeight + self.dynamicMainContentHeight
+        }
+        else {
             // When not dynamic let it take all available space
             return nil
         }
@@ -75,6 +79,10 @@ internal extension BottomSheetView {
         // Only add safe area when `dynamicBottom` and not on iPad floating or Mac
         if self.bottomSheetPosition == .dynamicBottom && !self.isIPadFloatingOrMac {
 #if !os(macOS)
+            // use custom offset for `dynamic` modes
+            if let customOffset = self.configuration.customBottomOffset {
+                return customOffset
+            }
             // Safe area as height (iPhone)
             return UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 20
 #else

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -65,7 +65,6 @@ internal extension BottomSheetView {
             // When dynamic return safe area and header height
             return self.bottomPositionSafeAreaHeight + self.headerContentHeight
         } else if self.bottomSheetPosition.isDynamic && self.bottomSheetPosition == .dynamic {
-            print("headerContentHeight: \(headerContentHeight), dynamicMainContentHeight: \(dynamicMainContentHeight)")
             return self.bottomPositionSafeAreaHeight + self.headerContentHeight + self.dynamicMainContentHeight
         }
         else {

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -28,7 +28,8 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
         lhs.sheetWidth == rhs.sheetWidth &&
-        lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight
+        lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight &&
+        lhs.customBottomOffset == rhs.customBottomOffset
     }
     
     var animation: Animation? = .spring(
@@ -61,4 +62,5 @@ internal class BottomSheetConfiguration: Equatable {
     var iPadFloatingSheet: Bool = true
     var sheetWidth: BottomSheetWidth = .platformDefault
     var accountForKeyboardHeight: Bool = false
+    var customBottomOffset: CGFloat? = nil
 }


### PR DESCRIPTION
# Change

I made a rather tiny change for convenience in a project where I use your awesome bottomsheet implementation. That is, normally the content offset when the bottomsheet is dragged to the bottom of the screen is tied to the safe area of the device. As we have a TabBar and optional sticky content at the bottom of the screen, we want the bottomsheet to align above this content when dragged all the way down. Hence we added an additional argument to the bottomsheet initializer to set this offset on top of the safe area for a bit more control over the alignment process. This is just our change, I hope this can be in the one or other way be integrated as a feature. Changes to the adaptations to better match the coding style of the project are appreciated. I also added a screenshot to illustrate the change below.

# Screenshot
<img width="349" alt="offset_includes_tabbar" src="https://github.com/lucaszischka/BottomSheet/assets/50778908/3591e46e-2979-4920-8c63-2b37c59268de">
